### PR TITLE
Add strict_mode option to ensure HTTP calls DO NOT get made

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -10,5 +10,6 @@ config :exvcr, [
   filter_request_headers: [],
   response_headers_blacklist: [],
   ignore_localhost: false,
-  enable_global_settings: false
+  enable_global_settings: false,
+  strict_mode: false
 ]

--- a/lib/exvcr/config.ex
+++ b/lib/exvcr/config.ex
@@ -84,4 +84,11 @@ defmodule ExVCR.Config do
   def ignore_localhost(value) do
     Setting.set(:ignore_localhost, value)
   end
+
+  @doc """
+  Throw error if there is no matching cassette for an HTTP request
+  """
+  def strict_mode(value) do
+    Setting.set(:strict_mode, value)
+  end
 end

--- a/lib/exvcr/config_loader.ex
+++ b/lib/exvcr/config_loader.ex
@@ -56,5 +56,9 @@ defmodule ExVCR.ConfigLoader do
     if env[:ignore_localhost] != nil do
       Config.ignore_localhost(env[:ignore_localhost])
     end
+
+    if env[:strict_mode] != nil do
+      Config.strict_mode(env[:strict_mode])
+    end
   end
 end

--- a/lib/exvcr/handler.ex
+++ b/lib/exvcr/handler.ex
@@ -14,7 +14,9 @@ defmodule ExVCR.Handler do
     if ignore_request?(request, recorder) do
       get_response_from_server(request, recorder, false)
     else
-      get_response_from_cache(request, recorder) || get_response_from_server(request, recorder, true)
+      get_response_from_cache(request, recorder) ||
+      ignore_server_fetch!(request, recorder) ||
+      get_response_from_server(request, recorder, true)
     end
   end
 
@@ -180,6 +182,21 @@ defmodule ExVCR.Handler do
     else
       false
     end
+  end
+
+  defp ignore_server_fetch!(request, recorder) do
+    strict_mode = ExVCR.Recorder.options(recorder)[:strict_mode] || ExVCR.Setting.get(:strict_mode)
+    if strict_mode do
+      message = """
+      A matching cassette was not found for this request.
+
+      An error was raised, rather than recording a cassette, because the option `strict_mode` is turned on.
+
+      Request: #{inspect(request)}
+      """
+      raise ExVCR.RequestNotMatchError, message: message
+    end
+    false
   end
 
   defp raise_error_if_cassette_already_exists(recorder, request_description) do

--- a/test/strict_mode_test.exs
+++ b/test/strict_mode_test.exs
@@ -1,0 +1,51 @@
+defmodule ExVCR.StrictModeTest do
+  use ExVCR.Mock
+  use ExUnit.Case, async: false
+
+  @dummy_cassette_dir "tmp/vcr_tmp/vcr_cassettes_strict_mode"
+  @port 34007
+  @url "http://localhost:#{@port}/server"
+  @http_server_opts [path: "/server", port: @port, response: "test_response"]
+
+  setup_all do
+    File.rm_rf(@dummy_cassette_dir)
+
+    on_exit fn ->
+      File.rm_rf(@dummy_cassette_dir)
+      HttpServer.stop(@port)
+      :ok
+    end
+
+    HTTPotion.start
+    HttpServer.start(@http_server_opts)
+    :ok
+  end
+
+  setup do
+    ExVCR.Config.cassette_library_dir(@dummy_cassette_dir)
+  end
+
+  test "it makes HTTP calls if not set" do
+    use_cassette "strict_mode_off", strict_mode: false do
+      assert HTTPotion.get(@url, []).body =~ ~r/test_response/
+    end
+  end
+
+  test "it throws an error when set and no cassette recorded" do
+    use_cassette "strict_mode_on", strict_mode: true do
+      assert_raise ExVCR.RequestNotMatchError, fn ->
+       HTTPotion.get(@url, []).body =~ ~r/test_response/
+      end
+    end
+  end
+
+  test "it uses a cassette if it exists" do
+    use_cassette "strict_mode_cassette", strict_mode: false do
+      assert HTTPotion.get(@url, []).body =~ ~r/test_response/
+    end
+
+    use_cassette "strict_mode_cassette", strict_mode: true do
+      assert HTTPotion.get(@url, []).body =~ ~r/test_response/
+    end
+  end
+end


### PR DESCRIPTION
This change adds a new option called strict_mode. When turned on, if a matching cassette cannot be found, an error will be thrown.

## Problem
- In a large codebase (e.g. has hundreds of tests) it is hard to validate if every HTTP call has a cassette defined for it. With strict_mode turned, an HTTP call without a cassette will cause a test to fail, making it easy to identify which calls are missing cassettes.
- Some HTTP calls are destructive or mutate data and should never be called while running tests. Strict_mode enables ExVCR to be used for these HTTP calls without the risk of accidentally making an actual HTTP call