### PR TITLE
Use throw instead of raise

### DIFF
--- a/lib/exvcr/handler.ex
+++ b/lib/exvcr/handler.ex
@@ -194,7 +194,7 @@ defmodule ExVCR.Handler do
 
       Request: #{inspect(request)}
       """
-      raise ExVCR.RequestNotMatchError, message: message
+      throw(message)
     end
     false
   end

--- a/test/strict_mode_test.exs
+++ b/test/strict_mode_test.exs
@@ -33,8 +33,12 @@ defmodule ExVCR.StrictModeTest do
 
   test "it throws an error when set and no cassette recorded" do
     use_cassette "strict_mode_on", strict_mode: true do
-      assert_raise ExVCR.RequestNotMatchError, fn ->
+      try do
        HTTPotion.get(@url, []).body =~ ~r/test_response/
+       assert(false, "Shouldn't get here")
+      catch
+        "A matching cassette was not found" <> _ -> assert(true)
+        _ -> assert(false, "Encountered unexpected `throw`")
       end
     end
   end


### PR DESCRIPTION
## Why use `throw` not `raise`?
In practice there's a reasonable amount of code out in the wild that will handle any exception raised in order to give a reasonable default error message to an end user/consumer. For example, a controller might do something like:

```
  def controller_handle_request(conn, params) do
    make_http_call_that_may_raise()
  rescue
    _ -> return_nice_error()
  end
```

Unfortunately if this controller is mocked by ExVCR an exception raised by `strict_mode` would also get handled by this controller :(

`throw`'s sit outside of exceptions, and won't get clobbered by any kind of `rescue`, thus surfacing `strict_mode` errors to developers in this scenario.